### PR TITLE
Restructure startup files

### DIFF
--- a/dotfiles/bash_profile
+++ b/dotfiles/bash_profile
@@ -1,4 +1,15 @@
 # vi:set ft=sh:
-[[ -e "$HOME/.profile" ]] && source "$HOME/.profile" # Load the default .profile
 
-[[ -f $HOME/.bash_profile.local ]] && source $HOME/.bash_profile.local
+[[ -f "$HOME/.profile" ]] && source "$HOME/.profile"
+
+if [[ $( uname -s ) == "Linux" && -f "$HOME/.bashrc" ]]; then
+    case "$-" in
+        *i*) [[ -f "$HOME/.bashrc" ]] && . "$HOME/.bashrc" ;;
+    esac
+fi
+
+if command -v rbenv > /dev/null 2>&1; then
+    export PATH="$HOME/.rbenv/shims:$PATH"
+fi
+
+[[ -f "$HOME/.bash_profile.local" ]] && source "$HOME/.bash_profile.local"

--- a/dotfiles/bashrc
+++ b/dotfiles/bashrc
@@ -33,5 +33,9 @@ shopt -s histappend histverify
 [[ -f $HOME/workflow/cdc/cdc.plugin.bash ]] && \
     source $HOME/workflow/cdc/cdc.plugin.bash
 
+if command -v rbenv > /dev/null 2>&1; then
+    eval "$( rbenv init - bash )"
+fi
+
 [[ -f $HOME/.shellrc ]] && source $HOME/.shellrc
 [[ -f $HOME/.bashrc.local ]] && source $HOME/.bashrc.local

--- a/dotfiles/profile
+++ b/dotfiles/profile
@@ -1,6 +1,3 @@
 # vi: set ft=sh:
 
-[[ $( uname -s ) == 'Linux' && -n "$BASH_VERSION" && -f "$HOME/.bashrc" ]] && \
-    source "$HOME/.bashrc"
-
-[[ -f $HOME/.profile.local ]] && source $HOME/.profile.local
+[ -f "$HOME/.profile.local" ] && source "$HOME/.profile.local"

--- a/dotfiles/shellrc
+++ b/dotfiles/shellrc
@@ -97,10 +97,6 @@ $HOME/bin/ruby:\
 $HOME/scripts/bin:\
 $PATH
 
-if command -v rbenv > /dev/null 2>&1; then
-    eval "$( rbenv init - )"
-fi
-
 source_config_files() {
     local file
 

--- a/dotfiles/zprofile
+++ b/dotfiles/zprofile
@@ -1,0 +1,5 @@
+# vi: ft=zsh :
+
+if command -v rbenv > /dev/null 2>&1; then
+  export PATH="$HOME/.rbenv/shims:$PATH"
+fi

--- a/dotfiles/zshrc
+++ b/dotfiles/zshrc
@@ -43,4 +43,8 @@ fi
     for file { [[ -f $file ]] && source "$file" }
 } $HOME/.opam/opam-init/init.zsh $HOME/.shellrc
 
+if command -v rbenv > /dev/null 2>&1; then
+    eval "$( rbenv init - zsh )"
+fi
+
 [[ -f $HOME/.zshrc.local ]] && source $HOME/.zshrc.local


### PR DESCRIPTION
This all started because codex couldn't see `rbenv/shims` so I needed to change some path stuff, then it evolved into a load order for zsh/bash files.